### PR TITLE
Actualización de año 2025→2026 con año dinámico y analytics con Goatcounter

### DIFF
--- a/acerca-drama.html
+++ b/acerca-drama.html
@@ -40,9 +40,12 @@
         </main>
         
         <footer>
-            <p>© 2025 Ministerio de Gestión del Drama</p>
+            <p>© <span class="current-year">2026</span> Ministerio de Gestión del Drama</p>
             <p><a href="index.html">Volver a la página principal</a></p>
         </footer>
     </div>
+    <script src="script.js"></script>
+    <script data-goatcounter="https://amigashacker.goatcounter.com/count"
+            async src="//gc.zgo.at/count.js"></script>
 </body>
 </html>

--- a/formulario-drama.html
+++ b/formulario-drama.html
@@ -19,7 +19,7 @@
                     <h1><a href="index.html">Ministerio de Gestión del Drama</a></h1>
                     <p class="tagline">Formulario Oficial de Reporte de Drama</p>
                 </div>
-                <div class="stamp">FORMULARIO MGD-2025</div>
+                <div class="stamp">FORMULARIO MGD-<span class="current-year">2026</span></div>
             </div>
         </header>
         
@@ -119,7 +119,7 @@
         </main>
         
         <footer>
-            <p>© 2025 Ministerio de Gestión del Drama - <a href="acerca-drama.html">Acerca del Ministerio</a></p>
+            <p>© <span class="current-year">2026</span> Ministerio de Gestión del Drama - <a href="acerca-drama.html">Acerca del Ministerio</a></p>
             <p><a href="index.html">Volver a la página principal</a></p>
         </footer>
     </div>
@@ -132,5 +132,7 @@
     </div>
     
     <script src="script.js"></script>
+    <script data-goatcounter="https://amigashacker.goatcounter.com/count"
+            async src="//gc.zgo.at/count.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -76,8 +76,11 @@
         </main>
         
         <footer>
-            <p>© 2025 Ministerio de Gestión del Drama - <a href="acerca-drama.html">Acerca del Ministerio</a></p>
+            <p>© <span class="current-year">2026</span> Ministerio de Gestión del Drama - <a href="acerca-drama.html">Acerca del Ministerio</a></p>
         </footer>
     </div>
+    <script src="script.js"></script>
+    <script data-goatcounter="https://amigashacker.goatcounter.com/count"
+            async src="//gc.zgo.at/count.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,9 @@
 document.addEventListener('DOMContentLoaded', function() {
+    // Actualizar año dinámicamente en todos los elementos con clase 'current-year'
+    document.querySelectorAll('.current-year').forEach(function(el) {
+        el.textContent = new Date().getFullYear();
+    });
+
     // Mostrar campo de otra categoría si se selecciona "Otro"
     const categoriaDrama = document.getElementById('categoriaDrama');
     const otraCategoriaContainer = document.getElementById('otraCategoriaContainer');
@@ -331,7 +336,7 @@ async function generarPDF() {
     doc.setFontSize(10);
     doc.setTextColor(100, 100, 100);
     doc.text('Este documento es parte de una iniciativa artística y no tiene validez legal.', 105, 255, { align: 'center' });
-    doc.text('© 2025 Ministerio de Gestión del Drama', 105, 260, { align: 'center' });
+    doc.text(`© ${new Date().getFullYear()} Ministerio de Gestión del Drama`, 105, 260, { align: 'center' });
     
     // Añadir nota sobre el drama en letra pequeña
     doc.setFontSize(8);
@@ -340,7 +345,12 @@ async function generarPDF() {
     
     // Guardar PDF
     doc.save(`Tramite-Drama-${idTramite}.pdf`);
-    
+
+    // Registrar evento de generación de PDF en Goatcounter
+    if (window.goatcounter && window.goatcounter.count) {
+        window.goatcounter.count({ path: 'pdf-generado', event: true });
+    }
+
     // Mostrar mensaje de éxito
     alert('Su trámite ha sido procesado correctamente. El comprobante se está descargando.');
 }


### PR DESCRIPTION
- Reemplazo de todas las referencias hardcodeadas de 2025 por año dinámico via JS (new Date().getFullYear()) en HTML y en el PDF generado
- Agregado de script.js a index.html y acerca-drama.html
- Integración de Goatcounter para analytics sin cookies ni tracking personal
- Evento personalizado 'pdf-generado' al generar cada PDF